### PR TITLE
fix: typo in optic-release-automation-action version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: nearform/optic-release-automation-action@2.3.0
+      - uses: nearform/optic-release-automation-action@v2.3.0
         with:
           github-token: ${{ secrets.github_token }}
           npm-token: ${{ secrets[format('NPM_TOKEN_{0}', github.actor)] || secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixed a typo in the version.

Closes #100 