### PR TITLE
chore: Updated README for KVv2 usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,5 @@ jobs:
           github-token: ${{ secrets.github_token }}
           npm-token: ${{ secrets[format('NPM_TOKEN_{0}', github.actor)] || secrets.NPM_TOKEN }}
           optic-token: ${{ secrets[format('OPTIC_TOKEN_{0}', github.actor)] || secrets.OPTIC_TOKEN }}
-          commit-message: ${{ github.event.inputs.commit-message }}
           semver: ${{ github.event.inputs.semver }}
           npm-tag: ${{ github.event.inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,6 @@ on:
         description: "The semver to use"
         required: true
         default: "patch"
-      tag:
-        description: "The npm tag"
-        required: false
-        default: "latest"
-      commit-message:
-        description: "The commit message template"
-        required: false
-        default: "Release {version}"
   pull_request:
     types: [closed]
 
@@ -28,4 +20,3 @@ jobs:
           npm-token: ${{ secrets[format('NPM_TOKEN_{0}', github.actor)] || secrets.NPM_TOKEN }}
           optic-token: ${{ secrets[format('OPTIC_TOKEN_{0}', github.actor)] || secrets.OPTIC_TOKEN }}
           semver: ${{ github.event.inputs.semver }}
-          npm-tag: ${{ github.event.inputs.tag }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI](https://github.com/nearform/fastify-secrets-hashicorp/workflows/CI/badge.svg)
 
-Fastify secrets plugin for [HashiCorp Vault](https://www.vaultproject.io) ([KV Secrets Engine - Version 1](https://www.vaultproject.io/docs/secrets/kv/kv-v1)).
+Fastify secrets plugin for [HashiCorp Vault](https://www.vaultproject.io). The plugin supports both [KV Secrets Engine - Version 2](https://www.vaultproject.io/docs/secrets/kv/kv-v2) (default) and [KV Secrets Engine - Version 1](https://www.vaultproject.io/docs/secrets/kv/kv-v1) (need to enable via [useKVv1](#clientoptionsusekvv1) flag).
 
 ## Installation
 


### PR DESCRIPTION
Updated README for KVv2 usage and also removed `commit-message` from release workflow as it's not supported yet in v2.3.0 (it throws a warning in the console).