### PR TITLE
chore: enabling npm provenance integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: nearform-actions/optic-release-automation-action@v4
         with:
@@ -33,3 +34,4 @@ jobs:
             secrets.OPTIC_TOKEN }}
           semver: ${{ github.event.inputs.semver }}
           build-command: npm i
+          provenance: true


### PR DESCRIPTION
- Resolves #156  
- Enabling NPM Provenance beta integration when publishing new versions to NPM.
- Resolves partially https://github.com/nearform/hub-draft-issues/issues/247