### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-standard": "^5.0.0",
     "fastify": "^4.0.3",
-    "husky": "^8.0.1",
+    "husky": "^9.0.11",
     "lint-staged": "^14.0.0",
     "prettier": "^3.0.1",
     "proxyquire": "^2.1.3",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)