### PR TITLE
feat(types): add TypeScript definitions and tstyche type tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 20
           - 22
+          - 24
+          - 26
     services:
       vault:
         image: vault:1.6.2

--- a/README.md
+++ b/README.md
@@ -41,6 +41,60 @@ fastify.ready().then(() => {
 })
 ```
 
+### TypeScript
+
+The package ships TypeScript declarations via `types/index.d.ts`. The same
+example as a `.ts` file:
+
+```ts
+import Fastify from 'fastify'
+import fastifySecretsHashiCorp from 'fastify-secrets-hashicorp'
+
+const fastify = Fastify()
+
+fastify.register(fastifySecretsHashiCorp, {
+  secrets: {
+    dbPassword: {
+      name: 'secret-name',
+      key: 'value'
+    }
+  },
+  clientOptions: {
+    vaultOptions: {
+      token: 'example-token',
+      endpoint: 'http://127.0.0.1:8200'
+    },
+    mountPoint: 'example-mount'
+  }
+})
+
+await fastify.ready()
+// fastify.secrets is typed as Record<string, string | undefined>
+console.log(fastify.secrets.dbPassword)
+```
+
+If you want the captured secret keys to be enumerable at runtime (e.g. for
+introspection in tooling or tests), use the factory export. It returns a
+plugin with the captured keys attached on the `kInferred` symbol:
+
+```ts
+import { createHashiCorpSecretsPlugin, kInferred } from 'fastify-secrets-hashicorp'
+
+const plugin = createHashiCorpSecretsPlugin({
+  secrets: {
+    dbPassword: { name: 'secret-name', key: 'value' }
+  }
+})
+
+console.log(Object.keys(plugin[kInferred] ?? {})) // ['dbPassword']
+
+fastify.register(plugin)
+```
+
+Note: `fastify.secrets` is typed as `Record<string, string | undefined>` from
+a module augmentation — it is not narrowed to the literal keys from the
+factory. Narrowing that would require a Fastify-side typing change.
+
 ### Plugin options
 
 Assuming a secret has been written [using the vault CLI](https://www.vaultproject.io/docs/commands/write#examples) like this:

--- a/lib/fastify-secrets-hashicorp.js
+++ b/lib/fastify-secrets-hashicorp.js
@@ -4,6 +4,35 @@ const { buildPlugin } = require('fastify-secrets-core')
 
 const HashiCorpClient = require('./client')
 
-module.exports = buildPlugin(HashiCorpClient, {
+const kInferred = Symbol.for('fastify-secrets-hashicorp.inferred')
+
+const defaultPlugin = buildPlugin(HashiCorpClient, {
   name: 'fastify-secrets-hashicorp'
 })
+
+function createHashiCorpSecretsPlugin(options) {
+  if (!options || typeof options !== 'object') {
+    throw new Error('fastify-secrets-hashicorp: options object is required')
+  }
+
+  if (!options.secrets || typeof options.secrets !== 'object' || Object.keys(options.secrets).length === 0) {
+    throw new Error('fastify-secrets-hashicorp: options.secrets must be a non-empty object')
+  }
+
+  const inferred = {}
+  for (const key of Object.keys(options.secrets)) {
+    inferred[key] = true
+  }
+
+  const plugin = buildPlugin(HashiCorpClient, {
+    name: 'fastify-secrets-hashicorp'
+  })
+  plugin[kInferred] = inferred
+
+  return plugin
+}
+
+module.exports = defaultPlugin
+module.exports.default = defaultPlugin
+module.exports.createHashiCorpSecretsPlugin = createHashiCorpSecretsPlugin
+module.exports.kInferred = kInferred

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/nearform/fastify-secrets-hashicorp#readme",
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "devDependencies": {
     "c8": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "3.1.2",
   "description": "Fastify secrets plugin for HashiCorp Vault",
   "main": "lib/fastify-secrets-hashicorp.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "lint": "eslint lib test",
     "lint:fix": "npm run lint -- --fix",
     "lint:staged": "lint-staged",
-    "test": "c8 --100 node --test"
+    "test": "c8 --100 node --test && tstyche"
   },
   "repository": {
     "type": "git",
@@ -42,7 +43,8 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.0.4",
     "prettier": "^3.4.2",
-    "proxyquire": "^2.1.3"
+    "proxyquire": "^2.1.3",
+    "tstyche": "^7.2.1"
   },
   "lint-staged": {
     "*.js": [

--- a/test/factory.test.js
+++ b/test/factory.test.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const { test } = require('node:test')
+
+const Fastify = require('fastify')
+
+const { createHashiCorpSecretsPlugin, kInferred } = require('..')
+
+test('createHashiCorpSecretsPlugin', async (t) => {
+  await t.test('returns a plugin function with kInferred marker', (t) => {
+    const plugin = createHashiCorpSecretsPlugin({
+      secrets: {
+        dbPassword: { name: 'database', key: 'password' },
+        apiToken: { name: 'api', key: 'token' }
+      }
+    })
+
+    t.assert.equal(typeof plugin, 'function', 'returns a function')
+    t.assert.deepStrictEqual(
+      plugin[kInferred],
+      { dbPassword: true, apiToken: true },
+      'attaches captured keys on kInferred'
+    )
+  })
+
+  await t.test('captures a single secret', (t) => {
+    const plugin = createHashiCorpSecretsPlugin({
+      secrets: { onlyOne: { name: 'one' } }
+    })
+
+    t.assert.deepStrictEqual(plugin[kInferred], { onlyOne: true }, 'attaches the single captured key')
+  })
+
+  await t.test('throws when secrets is missing', (t) => {
+    t.assert.throws(
+      () => createHashiCorpSecretsPlugin({}),
+      /options\.secrets must be a non-empty object/,
+      'rejects missing secrets'
+    )
+  })
+
+  await t.test('throws when secrets is an empty object', (t) => {
+    t.assert.throws(
+      () => createHashiCorpSecretsPlugin({ secrets: {} }),
+      /options\.secrets must be a non-empty object/,
+      'rejects empty secrets'
+    )
+  })
+
+  await t.test('throws when options is missing', (t) => {
+    t.assert.throws(() => createHashiCorpSecretsPlugin(), /options object is required/, 'rejects missing options')
+  })
+
+  await t.test('returns a plugin that registers on a Fastify instance', async (t) => {
+    const fastify = Fastify({ logger: false })
+    const plugin = createHashiCorpSecretsPlugin({
+      secrets: { dbPassword: { name: 'database', key: 'password' } },
+      clientOptions: {
+        vaultOptions: { endpoint: 'http://127.0.0.1:8200' }
+      }
+    })
+
+    t.assert.doesNotThrow(() => fastify.register(plugin), 'accepts register()')
+
+    await fastify.close()
+  })
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,197 @@
+import type { FastifyPluginAsync, FastifyInstance } from 'fastify'
+
+/**
+ * Shared symbol used by `createHashiCorpSecretsPlugin` to attach the
+ * captured secret keys to the returned plugin.
+ *
+ * Declared here as a `unique symbol` so it can be used both as a property
+ * key in the type system and (when re-exported as a value) as the
+ * `Symbol.for('fastify-secrets-hashicorp.inferred')` reference at runtime.
+ */
+export const kInferred: unique symbol
+
+/**
+ * Options for the underlying HashiCorp Vault client (node-vault).
+ *
+ * Re-declared locally because `node-vault` does not ship its own TypeScript
+ * definitions. Mirrors `NodeVault.VaultOptions` from
+ * https://github.com/kr1sp1n/node-vault/blob/main/index.d.ts
+ */
+interface VaultOptions {
+  /**
+   * Vault API version. Defaults to `'v1'` when not set.
+   */
+  apiVersion?: string
+
+  /**
+   * Vault endpoint. Defaults to `process.env.VAULT_ADDR` or
+   * `'http://127.0.0.1:8200'`.
+   */
+  endpoint?: string
+
+  /**
+   * Vault namespace (Vault Enterprise).
+   */
+  namespace?: string
+
+  /**
+   * Path prefix appended to every request path.
+   */
+  pathPrefix?: string
+
+  /**
+   * Vault access token. Defaults to `process.env.VAULT_TOKEN`.
+   */
+  token?: string
+
+  /**
+   * Set to `true` to disable custom HTTP verbs (e.g. `LIST`).
+   */
+  noCustomHTTPVerbs?: boolean
+
+  /**
+   * Extra request options forwarded to the underlying HTTP client.
+   */
+  requestOptions?: Record<string, unknown>
+
+  /**
+   * Custom Promise implementation.
+   */
+  Promise?: PromiseConstructor
+
+  /**
+   * Custom logger; receives debug output.
+   */
+  debug?: (...args: unknown[]) => void
+}
+
+/**
+ * Reference to a single secret stored in HashiCorp Vault.
+ *
+ * Matches the shape consumed by `HashiCorpClient#get` in `lib/client.js`.
+ */
+interface HashiCorpSecretReference {
+  /**
+   * The Vault secret name (i.e. the path under the mount point).
+   */
+  name: string
+
+  /**
+   * The key inside the secret payload to read. Defaults to `'value'`.
+   */
+  key?: string
+}
+
+/**
+ * Options forwarded to the `HashiCorpClient` constructor.
+ *
+ * Mirrors the destructuring performed in `lib/client.js:10`.
+ */
+interface HashiCorpClientOptions {
+  /**
+   * Mount point of the KV secrets engine. Defaults to `'secret'`.
+   */
+  mountPoint?: string
+
+  /**
+   * Read from KV Secrets Engine v1 instead of v2. Defaults to `false`.
+   */
+  useKVv1?: boolean
+
+  /**
+   * Options forwarded to `node-vault`.
+   */
+  vaultOptions?: VaultOptions
+}
+
+/**
+ * Default shape of `fastify.secrets` after registration.
+ *
+ * Each entry is `string | undefined` because TypeScript's `Record` indexing
+ * always allows `undefined`. At runtime the plugin populates each entry
+ * before `ready()` resolves.
+ */
+type SecretsShape = Record<string, string | undefined>
+
+/**
+ * Plugin registration options.
+ *
+ * Mirrors the documented `fastify-secrets-core` plugin options.
+ */
+interface Options {
+  /**
+   * Object mapping user-defined secret names to their Vault references.
+   */
+  secrets?: Record<string, HashiCorpSecretReference>
+
+  /**
+   * Options forwarded to the underlying `HashiCorpClient`.
+   */
+  clientOptions?: HashiCorpClientOptions
+
+  /**
+   * Place secrets under `fastify.secrets[namespace]` instead of
+   * `fastify.secrets`.
+   */
+  namespace?: string
+
+  /**
+   * Number of parallel `client.get` calls. Defaults to `5`.
+   */
+  concurrency?: number
+
+  /**
+   * Rename the `refresh` method (e.g. to avoid clashes with a secret name).
+   */
+  refreshAlias?: string
+}
+
+/**
+ * Augments the Fastify instance with the `secrets` decorator.
+ */
+declare module 'fastify' {
+  interface FastifyInstance {
+    secrets: SecretsShape
+  }
+}
+
+declare const fastifySecretsHashiCorp: FastifyPluginAsync<Options>
+
+declare namespace fastifySecretsHashiCorp {
+  export {
+    HashiCorpSecretReference,
+    HashiCorpClientOptions,
+    Options,
+    SecretsShape,
+    VaultOptions
+  }
+}
+
+/**
+ * Create a HashiCorp secrets plugin instance from explicit options.
+ *
+ * At runtime this captures the keys of the `secrets` option, validates that
+ * it is a non-empty object, and returns a `fastify-plugin`-wrapped plugin
+ * function with the captured keys attached on the shared `kInferred` symbol.
+ *
+ * The returned plugin function is functionally identical to the default
+ * export.
+ *
+ * Note: this factory does not narrow `fastify.secrets` after registration —
+ * Fastify's `register()` typing returns the same `FastifyInstance`
+ * regardless of plugin return type.
+ */
+export function createHashiCorpSecretsPlugin<SecretsT extends Record<string, HashiCorpSecretReference>>(
+  options: Options & { secrets: SecretsT }
+): FastifyPluginAsync<Options> & {
+  readonly [kInferred]?: { [K in keyof SecretsT]: true }
+}
+
+export type {
+  Options,
+  HashiCorpSecretReference,
+  HashiCorpClientOptions,
+  SecretsShape,
+  VaultOptions
+}
+export default fastifySecretsHashiCorp

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -1,0 +1,134 @@
+import fastifySecretsHashiCorp, {
+  createHashiCorpSecretsPlugin,
+  kInferred
+} from './index.js'
+import { describe, expect, test } from 'tstyche'
+import fastify, { type FastifyInstance } from 'fastify'
+
+function withServer(
+  runAssertions: (server: FastifyInstance) => void,
+  options: fastifySecretsHashiCorp.Options = {
+    secrets: { dbPassword: { name: 'database', key: 'password' } }
+  }
+): void {
+  const server = fastify()
+  server.register(fastifySecretsHashiCorp, options)
+  server.after(() => runAssertions(server))
+}
+
+describe('fastify-secrets-hashicorp', () => {
+  describe('default export', () => {
+    test('registers via the default export', () => {
+      withServer(() => {})
+    })
+
+    test('secrets is typed as Record<string, string | undefined>', () => {
+      withServer((server) => {
+        expect(server.secrets).type.toBe<fastifySecretsHashiCorp.SecretsShape>()
+      })
+    })
+
+    test('accepts the full clientOptions shape', () => {
+      withServer(() => {}, {
+        secrets: {
+          dbPassword: { name: 'database', key: 'password' }
+        },
+        clientOptions: {
+          mountPoint: 'myproject',
+          useKVv1: true,
+          vaultOptions: {
+            endpoint: 'http://127.0.0.1:8200',
+            token: 'example-token'
+          }
+        }
+      })
+    })
+
+    test('accepts a namespace', () => {
+      withServer(() => {}, {
+        namespace: 'db',
+        secrets: {
+          password: { name: 'database', key: 'password' }
+        }
+      })
+    })
+
+    test('accepts concurrency and refreshAlias', () => {
+      withServer(() => {}, {
+        secrets: { token: { name: 'api', key: 'value' } },
+        concurrency: 1,
+        refreshAlias: 'update'
+      })
+    })
+  })
+
+  describe('createHashiCorpSecretsPlugin factory', () => {
+    test('returns a registerable plugin function', () => {
+      const server = fastify()
+      const plugin = createHashiCorpSecretsPlugin({
+        secrets: {
+          dbPassword: { name: 'database', key: 'password' }
+        }
+      })
+
+      expect(plugin).type.toBeAssignableTo<Parameters<typeof server.register>[0]>()
+    })
+
+    test('attaches captured keys on the kInferred symbol', () => {
+      const plugin = createHashiCorpSecretsPlugin({
+        secrets: {
+          dbPassword: { name: 'database', key: 'password' },
+          apiToken: { name: 'api', key: 'token' }
+        }
+      })
+
+      expect(plugin[kInferred]).type.toBe<{ dbPassword: true; apiToken: true } | undefined>()
+    })
+
+    test('captures a single key on the kInferred symbol', () => {
+      const plugin = createHashiCorpSecretsPlugin({
+        secrets: {
+          onlyOne: { name: 'one' }
+        }
+      })
+
+      expect(plugin[kInferred]).type.toBe<{ onlyOne: true } | undefined>()
+    })
+
+    test('accepts the full clientOptions shape', () => {
+      const server = fastify()
+      const plugin = createHashiCorpSecretsPlugin({
+        secrets: {
+          password: { name: 'database', key: 'password' }
+        },
+        clientOptions: {
+          mountPoint: 'myproject',
+          useKVv1: false,
+          vaultOptions: {
+            endpoint: 'http://127.0.0.1:8200'
+          }
+        }
+      })
+
+      server.register(plugin)
+      server.after(() => {
+        expect(server.secrets).type.toBe<fastifySecretsHashiCorp.SecretsShape>()
+      })
+    })
+
+    test('accepts a namespace', () => {
+      const server = fastify()
+      const plugin = createHashiCorpSecretsPlugin({
+        namespace: 'db',
+        secrets: {
+          password: { name: 'database', key: 'password' }
+        }
+      })
+
+      server.register(plugin)
+      server.after(() => {
+        expect(server.secrets).type.toBe<fastifySecretsHashiCorp.SecretsShape>()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This pull request adds TypeScript support and improves developer ergonomics for the `fastify-secrets-hashicorp` package. It introduces a new plugin factory function for better TypeScript introspection, ships TypeScript declaration files, and adds comprehensive tests for the new features. The documentation is also updated to reflect these changes.

**TypeScript support and developer ergonomics:**

* Added TypeScript declaration file (`types/index.d.ts`) and included it in the package exports, enabling out-of-the-box TypeScript support. (`package.json`)
* Introduced a new `createHashiCorpSecretsPlugin` factory function that returns a plugin with a `kInferred` symbol property listing captured secret keys, improving runtime introspection and tooling support. (`lib/fastify-secrets-hashicorp.js`)
* Exported the `kInferred` symbol for external use, allowing developers to programmatically access inferred secret keys. (`lib/fastify-secrets-hashicorp.js`)

**Documentation and testing:**

* Updated the `README.md` to document TypeScript usage, the new factory function, and the `kInferred` symbol, with code examples for both JavaScript and TypeScript users.
* Added new tests for the factory function and TypeScript types, ensuring correct plugin creation, error handling, and type inference. (`test/factory.test.js`, `types/index.tst.ts`) [[1]](diffhunk://#diff-387697e213dd87614ce36313f9fd041dec37ea599e71e93f84ff91528bf108cdR1-R67) [[2]](diffhunk://#diff-56661e430327f6904e432c9bfee148bc22cc30cd35468afd209180ae0bb1755dR1-R134)

**Tooling:**

* Added `tstyche` as a dev dependency and integrated it into the test script for type-level testing. (`package.json`) [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R6-R11) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L45-R47)